### PR TITLE
Add `ignore_unknown_options` in `cli.command`

### DIFF
--- a/git_externals/cli.py
+++ b/git_externals/cli.py
@@ -68,7 +68,7 @@ def cli(ctx, with_color):
             gitext_st(())
 
 
-@cli.command('foreach')
+@cli.command('foreach', context_settings=dict(ignore_unknown_options=True))
 @click.option('--recursive/--no-recursive', help='If --recursive is specified, this command will recurse into nested externals', default=True)
 @click.argument('subcommand', nargs=-1, required=True)
 def gitext_foreach(recursive, subcommand):


### PR DESCRIPTION
This allows the use of options in the `foreach` subcommand.