### PR TITLE
Revert "Add `ignore_unknown_options` in `cli.command`"

### DIFF
--- a/git_externals/cli.py
+++ b/git_externals/cli.py
@@ -69,7 +69,7 @@ def cli(ctx, with_color):
             gitext_st(())
 
 
-@cli.command('foreach', context_settings=dict(ignore_unknown_options=True))
+@cli.command('foreach')
 @click.option('--recursive/--no-recursive', help='If --recursive is specified, this command will recurse into nested externals', default=True)
 @click.argument('subcommand', nargs=-1, required=True)
 def gitext_foreach(recursive, subcommand):


### PR DESCRIPTION
Reverts develersrl/git-externals#20

We can use the `--` separator, as noted in the readme:

```
$ git externals foreach -- git log --limit 1
```

This way we can keep a better error messages for mistyped options.