### PR TITLE
Hotfix/freeze not freezing

### DIFF
--- a/tests/svn-target-freeze-svn.t
+++ b/tests/svn-target-freeze-svn.t
@@ -15,9 +15,28 @@ Svn external freeze (with --vcs and --no-gitsvn):
   Retrieving changes from server:  trunk
   Updating to commit 10
 
-  $ cd test-repo-svn && svn log --limit 1
+  $ (cd test-repo-svn && svn log --limit 1)
   ------------------------------------------------------------------------
   r10 | naufraghi | 2017-02-02 23:06:36 +0000 (Thu, 02 Feb 2017) | 1 line
   
   Add citation
   ------------------------------------------------------------------------
+
+Test version bump:
+
+  $ (cd test-repo-svn && svnversion -c)
+  5:10
+
+  $ (cd test-repo-svn && svn update -rHEAD)
+  Updating '.':
+  A    docs
+  A    docs/docs.md
+  U    README.md
+   U   .
+  Updated to revision 15.
+
+  $ (cd test-repo-svn && svnversion -c)
+  5:15
+
+  $ git externals freeze
+  Freeze https://svn.riouxsvn.com/svn-test-repo/trunk at svn:r15

--- a/tests/svn-target-freeze-svn.t
+++ b/tests/svn-target-freeze-svn.t
@@ -27,12 +27,7 @@ Test version bump:
   $ (cd test-repo-svn && svnversion -c)
   5:10
 
-  $ (cd test-repo-svn && svn update -rHEAD)
-  Updating '.':
-  A    docs
-  A    docs/docs.md
-  U    README.md
-   U   .
+  $ (cd test-repo-svn && svn update -rHEAD | grep revision)
   Updated to revision 15.
 
   $ (cd test-repo-svn && svnversion -c)

--- a/tests/svn-target-freeze.t
+++ b/tests/svn-target-freeze.t
@@ -31,7 +31,7 @@ Svn external freeze (with --vcs):
   Fast-forwarded master to refs/remotes/git-svn.
   Checking out commit e05cc85567e5e18004ba1fc55ed7599ba94d2b5a
 
-  $ cd test-repo-svn && git log -1
+  $ (cd test-repo-svn && git log -1)
   commit e05cc85567e5e18004ba1fc55ed7599ba94d2b5a
   Author: naufraghi <naufraghi@fa4e49d6-2000-40a9-909b-e7fe548600ae>
   Date:   Thu Feb 2 23:06:36 2017 +0000
@@ -39,3 +39,15 @@ Svn external freeze (with --vcs):
       Add citation
       
       git-svn-id: https://svn.riouxsvn.com/svn-test-repo/trunk@10 fa4e49d6-2000-40a9-909b-e7fe548600ae
+
+Test version bump:
+
+  $ (cd test-repo-svn && svnversion -c)
+  Unversioned directory
+
+  $ (cd test-repo-svn && git checkout master)
+  Previous HEAD position was e05cc85... Add citation
+  Switched to branch 'master'
+
+  $ git externals freeze
+  Freeze https://svn.riouxsvn.com/svn-test-repo/trunk at svn:r15

--- a/tests/svn-target-freeze.t
+++ b/tests/svn-target-freeze.t
@@ -43,7 +43,7 @@ Svn external freeze (with --vcs):
 Test version bump:
 
   $ (cd test-repo-svn && svnversion -c)
-  Unversioned directory
+  (Unversioned directory|exported) (re)
 
   $ (cd test-repo-svn && git checkout master)
   Previous HEAD position was e05cc85... Add citation


### PR DESCRIPTION
This regression entered as a late fix in the PR #18, the repo kind is the **remote** repo kind, the local storage in the case of `svn` can be both plain svn or git-svn, an this is still detected via trial-error.

- Move the svn stuff in the first branch of the if
- Add a test that triggers the regression