### PR TITLE
Reset `format.pretty` to grep git log output

### DIFF
--- a/git_externals/cli.py
+++ b/git_externals/cli.py
@@ -257,7 +257,7 @@ def gitext_freeze(externals):
             if match:
                 revision = "svn:r" + match.group(2)  # 565:56555 -> svn:r56555
             else:
-                message = git("log", "--grep", "git-svn-id:", "-1")
+                message = git("log", "--pretty=medium", "--grep", "git-svn-id:", "-1")
                 match = re_from_git_svn_id.search(message)
                 if match:
                     revision = "svn:r" + match.group(1)

--- a/git_externals/cli.py
+++ b/git_externals/cli.py
@@ -257,7 +257,7 @@ def gitext_freeze(externals):
             if match:
                 revision = "svn:r" + match.group(2)  # 565:56555 -> svn:r56555
             else:
-                message = git("log", "--pretty=medium", "--grep", "git-svn-id:", "-1")
+                message = git("log", "--format=%b", "--grep", "git-svn-id:", "-1")
                 match = re_from_git_svn_id.search(message)
                 if match:
                     revision = "svn:r" + match.group(1)

--- a/tests/svn-target-freeze.t
+++ b/tests/svn-target-freeze.t
@@ -51,3 +51,10 @@ Test version bump:
 
   $ git externals freeze
   Freeze https://svn.riouxsvn.com/svn-test-repo/trunk at svn:r15
+
+Test freeze ignores the current pretty.format git config:
+
+  $ git config --local pretty.format '%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset'
+
+  $ git externals freeze
+  Freeze https://svn.riouxsvn.com/svn-test-repo/trunk at svn:r15

--- a/tox.ini
+++ b/tox.ini
@@ -3,3 +3,4 @@ envlist = py27
 [testenv]
 deps = cram
 commands = cram tests/ -v
+passenv = HOME


### PR DESCRIPTION
If git-external user has something fancy for its `format.pretty` git option, `git externals freeze` fails.

For example having `'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset'` set in `~/.gitconfig` :smiley: 

Adding `--pretty-medium` option when using `git log --grep`

- [x] TODO: add regression test