### PR TITLE
git worktree support

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.0
+current_version = 0.5.0
 commit = True
 
 [bumpversion:file:git_externals/__init__.py]

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: python
 python:
   -  "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,9 @@ language: python
 python:
   -  "2.7"
 
-addons:
-  apt:
-    packages:
-    - git-svn
+before_install:
+  - sudo apt-get -qq update
+  - sudo apt-get install -y git-svn
 
 install: pip install tox
 script:

--- a/git_externals/__init__.py
+++ b/git_externals/__init__.py
@@ -1,3 +1,3 @@
 __author__ = "Daniele D'Orazio"
-__version__ = '0.4.0'
+__version__ = '0.5.0'
 __email__ = 'daniele@develer.com'

--- a/git_externals/cli.py
+++ b/git_externals/cli.py
@@ -49,7 +49,7 @@ def cli(ctx, with_color):
     replacement to svn externals
 
     This script works by cloning externals found in the `git_externals.json`
-    file into `.git/externals` and symlinks them to recreate the wanted
+    file into `.git_externals/` and symlinks them to recreate the wanted
     directory layout.
     """
     from git_externals import is_git_repo, externals_json_path, externals_root_path

--- a/git_externals/git_externals.py
+++ b/git_externals/git_externals.py
@@ -254,7 +254,7 @@ def externals_sanity_check():
         error('\n'.join(errmsg), exitcode=1)
     info('externals sanity check passed!')
 
-    # TODO: check if  we don't have duplicate entries under .git/externals
+    # TODO: check if we don't have duplicate entries under `.git_externals/`
 
 
 def filter_externals_not_needed(all_externals, entries):

--- a/git_externals/git_externals.py
+++ b/git_externals/git_externals.py
@@ -58,6 +58,7 @@ def externals_root_path(pwd=None):
     if os.path.exists(_old_root_path) and not os.path.exists(_root_path):
         info("Moving old externals path to new location")
         os.rename(_old_root_path, _root_path)
+        link_entries(load_gitexts(pwd))
     elif os.path.exists(_old_root_path) and os.path.exists(_root_path):
         error("Both new and old externals folder found, {} will be used".format(_root_path))
     return _root_path

--- a/tests/basic.t
+++ b/tests/basic.t
@@ -7,7 +7,7 @@ Usage without options:
     to svn externals
   
     This script works by cloning externals found in the `git_externals.json`
-    file into `.git/externals` and symlinks them to recreate the wanted
+    file into `.git_externals/` and symlinks them to recreate the wanted
     directory layout.
   
   Options:

--- a/tests/git-worktree.t
+++ b/tests/git-worktree.t
@@ -1,0 +1,24 @@
+Svn external in a git worktree:
+
+  $ mkdir master
+  $ cd master
+  $ git init .
+  Initialized empty Git repository in /tmp/cramtests-*/git-worktree.t/master/.git/ (glob)
+  $ git externals add -b trunk -c svn https://svn.riouxsvn.com/svn-test-repo/trunk ./ test-repo-svn > /dev/null 2>&1
+  $ git externals update > /dev/null 2>&1
+  $ ls . | grep test-repo-svn
+  test-repo-svn
+  $ git add git_externals.json
+  $ git commit -m"Add git_externals.json" git_externals.json | grep "create mode"
+   create mode 100644 git_externals.json
+
+Now we create a worktree ad try to update the externals there too
+
+  $ git worktree add ../test-worktree > /dev/null
+  Preparing ../test-worktree (identifier test-worktree)
+  $ cd ../test-worktree
+  $ ls . | grep test-repo-svn
+  [1]
+  $ git externals update > /dev/null 2>&1
+  $ ls . | grep test-repo-svn
+  test-repo-svn

--- a/tests/git-worktree.t
+++ b/tests/git-worktree.t
@@ -4,6 +4,8 @@ Svn external in a git worktree:
   $ cd master
   $ git init .
   Initialized empty Git repository in /tmp/cramtests-*/git-worktree.t/master/.git/ (glob)
+  $ git config user.email "externals@test.com"
+  $ git config user.name "Git Externals"
   $ git externals add -b trunk -c svn https://svn.riouxsvn.com/svn-test-repo/trunk ./ test-repo-svn > /dev/null 2>&1
   $ git externals update > /dev/null 2>&1
   $ ls . | grep test-repo-svn

--- a/tests/git-worktree.t
+++ b/tests/git-worktree.t
@@ -24,3 +24,26 @@ Now we create a worktree ad try to update the externals there too
   $ git externals update > /dev/null 2>&1
   $ ls . | grep test-repo-svn
   test-repo-svn
+
+Test the upgrade to the new storage folder `.git_externals/`
+
+  $ cd ../master
+  $ readlink -f test-repo-svn
+  /tmp/cramtests-*/git-worktree.t/master/.git_externals/trunk (glob)
+  $ mv .git_externals/ .git/externals
+  $ rm test-repo-svn
+  $ ln -s .git/externals/trunk ./test-repo-svn
+  $ readlink -f test-repo-svn  # check we restored the old version location
+  /tmp/cramtests-*/git-worktree.t/master/.git/externals/trunk (glob)
+
+  $ git externals update
+  Moving old externals path to new location
+  externals sanity check passed!
+  External trunk
+  Retrieving changes from server:  trunk
+  *-*-* *:*:* INFO[git-svn-clone-externals]: git svn rebase . (glob)
+  Current branch HEAD is up to date.
+  Checking out commit git-svn
+
+  $ readlink -f test-repo-svn  # check we updated the link too
+  /tmp/cramtests-*/git-worktree.t/master/.git_externals/trunk (glob)


### PR DESCRIPTION
See issue #14 

This features makes easier to keep a `master` and `release` branches with different externals versions, reducing strange errors that may append using a branch without updating the externals repos.

- [x] fix symlinks when moving the externals to the new location