### PR TITLE
Better discern stdout and err messages

### DIFF
--- a/git_externals/cli.py
+++ b/git_externals/cli.py
@@ -73,8 +73,12 @@ def cli(ctx, with_color):
 
 @cli.command('foreach')
 @click.option('--recursive/--no-recursive', help='If --recursive is specified, this command will recurse into nested externals', default=True)
+@click.option(
+    '--porcelain',
+    is_flag=True,
+    help='Give the output in an easy-to-parse format for scripts.')
 @click.argument('subcommand', nargs=-1, required=True)
-def gitext_foreach(recursive, subcommand):
+def gitext_foreach(recursive, porcelain, subcommand):
     """Evaluates an arbitrary shell command in each checked out external
     """
     from git_externals import externals_sanity_check, get_repo_name, foreach_externals_dir, root_path
@@ -85,6 +89,8 @@ def gitext_foreach(recursive, subcommand):
         try:
             info("External {}".format(get_repo_name(rel_url)), err=True)
             output = decode_utf8(command(*subcommand))
+            if porcelain: 
+                echo("[External={}]".format(os.getcwd()))
             info("Ok: CWD: {}, cmd: {}".format(os.getcwd(), subcommand), err=True)
             echo(output)
         except CommandError as err:

--- a/git_externals/cli.py
+++ b/git_externals/cli.py
@@ -130,7 +130,7 @@ def gitext_update(recursive, gitsvn, reset):
 @click.option(
     '--porcelain',
     is_flag=True,
-    help='Print output using the porcelain format, useful mostly for scripts')
+    help='Give the output in an easy-to-parse format for scripts.')
 @click.option(
     '--verbose/--no-verbose',
     is_flag=True,

--- a/git_externals/cli.py
+++ b/git_externals/cli.py
@@ -83,12 +83,12 @@ def gitext_foreach(recursive, subcommand):
 
     def run_command(rel_url, ext_path, targets):
         try:
-            info("External {}".format(get_repo_name(rel_url)))
+            info("External {}".format(get_repo_name(rel_url)), err=True)
             output = decode_utf8(command(*subcommand))
-            info("Ok: CWD: {}, cmd: {}".format(os.getcwd(), subcommand))
+            info("Ok: CWD: {}, cmd: {}".format(os.getcwd(), subcommand), err=True)
             echo(output)
         except CommandError as err:
-            info("Command error {} CWD: {}, cmd: {}".format(err, os.getcwd(), subcommand))
+            info("Command error {} CWD: {}, cmd: {}".format(err, os.getcwd(), subcommand), err=True)
             error(str(err), exitcode=err.errcode)
 
     foreach_externals_dir(root_path(), run_command, recursive=recursive)

--- a/git_externals/cli.py
+++ b/git_externals/cli.py
@@ -19,16 +19,16 @@ else:
 click.disable_unicode_literals_warning = True
 
 
-def echo(*args):
-    click.echo(u' '.join(args))
+def echo(*args, **kwargs):
+    click.echo(u' '.join(args), **kwargs)
 
 
-def info(*args):
-    click.secho(u' '.join(args), fg='blue')
+def info(*args, **kwargs):
+    click.secho(u' '.join(args), fg='blue', **kwargs)
 
 
 def error(*args, **kwargs):
-    click.secho(u' '.join(args), fg='red')
+    click.secho(u' '.join(args), fg='red', err=True)
     exitcode = kwargs.get('exitcode', 1)
     if exitcode is not None:
         sys.exit(exitcode)

--- a/git_externals/git_externals.py
+++ b/git_externals/git_externals.py
@@ -244,7 +244,7 @@ def externals_sanity_check():
     if errmsg is not None:
         errmsg.append("Please correct the corresponding {0} before proceeding".format(EXTERNALS_JSON))
         error('\n'.join(errmsg), exitcode=1)
-    info('externals sanity check passed!')
+    info('externals sanity check passed!', err=True)
 
     # TODO: check if  we don't have duplicate entries under .git/externals
 


### PR DESCRIPTION
Use stdout or stderr for messages output to the terminal by `git-externals`.
 - stdout: normal output, parsable output
 - stderr: error output, non parsable output, additional information