### PR TITLE
WIP: Add ls-files command

### DIFF
--- a/git_externals/gitext.completion.bash
+++ b/git_externals/gitext.completion.bash
@@ -22,6 +22,7 @@ _git_ext_cmds=" \
 add \
 diff \
 foreach \
+ls-files \
 info \
 freeze \
 remove \
@@ -113,10 +114,24 @@ __git_ext_diff ()
   __gitext_complete_externals "${cur}"
 }
 
-__git_ext_update_foreach ()
+__git_ext_update ()
 {
   local opts=""
   opts="--recursive --no-recursive --gitsvn --no-gitsvn --reset"
+  COMPREPLY=( ${COMPREPLY[@]:-} $(compgen -W "${opts}" -- "${cur}") )
+}
+
+__git_ext_foreach ()
+{
+  local opts=""
+  opts="--recursive --no-recursive --porcelain --no-porcelain"
+  COMPREPLY=( ${COMPREPLY[@]:-} $(compgen -W "${opts}" -- "${cur}") )
+}
+
+__git_ext_ls ()
+{
+  local opts=""
+  opts="--recursive --no-recursive --porcelain --no-porcelain"
   COMPREPLY=( ${COMPREPLY[@]:-} $(compgen -W "${opts}" -- "${cur}") )
 }
 
@@ -162,10 +177,14 @@ __git_externals ()
         __git_ext_info ;;
       status)
         __git_ext_status ;;
-      update|foreach)
-        __git_ext_update_foreach ;;
+      update)
+        __git_ext_update ;;
+      foreach)
+        __git_ext_foreach ;;
+      ls-files)
+        __git_ext_ls ;;
       add)
-        __git_ext_update_add ;;
+        __git_ext_add ;;
       esac # case ${cmd}
   fi # command specified
 


### PR DESCRIPTION
The goal is to propose a feature similar to `git ls-files` in order to list all the versioned file of one or more externals.

**WIP**

Todo list:
- [ ] as this branch is based off of a non-master branch (PR #40 pending), it will be required to set PR base to master once #40 has been merged
- [x] ls-files implementation for `git` and `git-svn` externals
- [ ] ls-files implementation for `git` and `git-svn` externals [Tests]
- [ ] ls-files implementation for `svn` externals
- [ ] ls-files implementation for `svn` externals [Tests]
- [x] recursion into nested externals
- [ ] recursion into nested externals [Tests]
- [x] porcelain output
- [ ] porcelain output [Tests]

The most *problematic* of this point is the implementation for svn externals. Probably an option to use the network (and thus running `svn ls -R`) or not (and use an equivalent of `find .` on windows) 